### PR TITLE
Minicorrección para la inclusión de signature policy en xades manifest

### DIFF
--- a/DemoFirmaManifest/FrmPrincipal.cs
+++ b/DemoFirmaManifest/FrmPrincipal.cs
@@ -71,6 +71,13 @@ namespace DemoFirmaManifest
             parametros.SignaturePackaging = SignaturePackaging.ENVELOPING;
             parametros.DataFormat = new DataFormat();
             parametros.DataFormat.MimeType = "text/xml";
+            parametros.SignaturePolicyInfo = new SignaturePolicyInfo
+            {
+                PolicyIdentifier = "rn:oid:2.16.724.1.3.1.1.2.1.8",
+                PolicyDigestAlgorithm = DigestMethod.SHA1,
+                PolicyHash = "VYICYpNOjso9g1mBiXDVxNORpKk=",
+                PolicyUri = "http://administracionelectronica.gob.es/es/ctt/politicafirma/politica_firma_AGE_v1_8.pdf"
+            };
 
             SignatureDocument documentoFirma;
 

--- a/FirmaXadesNet/Properties/AssemblyInfo.cs
+++ b/FirmaXadesNet/Properties/AssemblyInfo.cs
@@ -55,5 +55,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("2.2.0.0")]
-[assembly: AssemblyFileVersion("2.2.0.0")]
+[assembly: AssemblyVersion("2.2.1.0")]
+[assembly: AssemblyFileVersion("2.2.1.0")]

--- a/FirmaXadesNet/XadesService.cs
+++ b/FirmaXadesNet/XadesService.cs
@@ -1,4 +1,4 @@
-﻿// --------------------------------------------------------------------------------------------------------------------
+// --------------------------------------------------------------------------------------------------------------------
 // XadesService.cs
 //
 // FirmaXadesNet - Librería para la generación de firmas XADES
@@ -159,6 +159,11 @@ namespace FirmaXadesNet
             }
 
             SetSignatureId(signatureDocument.XadesSignature);
+
+            if (signatureDocument.Document == null)
+            {
+                signatureDocument.Document = new XmlDocument();
+            }
 
             PrepareSignature(signatureDocument, parameters);
 


### PR DESCRIPTION
Minicorrección para la inclusión de signature policy en xades manifest
El documento xml llegaba nulo para la creación de una etiqueta